### PR TITLE
feat: add runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
   cargo build --frozen --locked --offline --target-dir=/usr/local/target --target x86_64-unknown-linux-musl --release --all
 ARG TARGETPLATFORM
 ENV TARGETPLATFORM=${TARGETPLATFORM}
+COPY --from=ghcr.io/cosi-project/runtime:latest /runtime /binaries/runtime
 RUN --mount=type=cache,target=/usr/local/target \
   ./hack/binaries.sh
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -3,3 +3,4 @@ pub static GENERATORS: &str = "/system/generators";
 pub static PLUGINS: &str = "/system/plugins";
 pub static SOCKET_ENGINE: &str = "/system/engine.sock";
 pub static SOCKET_RUNTIME: &str = "/system/runtime.sock";
+pub static ADDRESS_RUNTIME: &str = "0.0.0.0:50000";

--- a/src/plugins/mount/main.rs
+++ b/src/plugins/mount/main.rs
@@ -26,6 +26,8 @@ async fn main() {
 
     let socket = buffer.as_str().to_owned();
 
+    println!("Registering at {}", socket);
+
     let r = plugin::register(socket.clone(), NAME.to_owned()).await;
 
     match r {

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -109,6 +109,7 @@ impl AsyncWrite for UnixStream {
 }
 
 pub mod process {
+    use crate::consts;
     use crate::unix::process::reaper::Reaper;
     use manager::Manager;
     use nix::unistd::Pid;
@@ -126,6 +127,7 @@ pub mod process {
             let mut child = match Command::new(executable.clone())
                 .stdout(Stdio::piped())
                 .stdin(Stdio::piped())
+                .args(&["--address", consts::ADDRESS_RUNTIME])
                 .spawn()
             {
                 Ok(child) => child,


### PR DESCRIPTION
This brings in the official `runtime` binary, which enables a working
system out of the box.

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>